### PR TITLE
Fix various commands failing in lieu of a default argument (and derpy CAS test)

### DIFF
--- a/IHbot/__main__.py
+++ b/IHbot/__main__.py
@@ -126,7 +126,7 @@ def test(bot: Bot, update: Update):
 def start(bot: Bot, update: Update, args: List[str] = None):
     bot.sendChatAction(update.effective_chat.id, "typing")  # Bot typing before send messages
     if update.effective_chat.type == "private":
-        if len(args) >= 1:
+        if args and len(args) >= 1:
             if args[0].lower() == "help":
                 send_help(update.effective_chat.id, HELP_STRINGS)
 

--- a/IHbot/__main__.py
+++ b/IHbot/__main__.py
@@ -123,7 +123,7 @@ def test(bot: Bot, update: Update):
     print(update.effective_message)
 
 
-def start(bot: Bot, update: Update, args: List[str]):
+def start(bot: Bot, update: Update, args: List[str] = None):
     bot.sendChatAction(update.effective_chat.id, "typing")  # Bot typing before send messages
     if update.effective_chat.type == "private":
         if len(args) >= 1:

--- a/IHbot/modules/admin.py
+++ b/IHbot/modules/admin.py
@@ -20,7 +20,7 @@ from IHbot.modules.log_channel import loggable
 @can_promote
 @user_admin
 @loggable
-def promote(bot: Bot, update: Update, args: List[str]) -> str:
+def promote(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat_id = update.effective_chat.id
     message = update.effective_message  # type: Optional[Message]
     chat = update.effective_chat  # type: Optional[Chat]
@@ -67,7 +67,7 @@ def promote(bot: Bot, update: Update, args: List[str]) -> str:
 @can_promote
 @user_admin
 @loggable
-def demote(bot: Bot, update: Update, args: List[str]) -> str:
+def demote(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     message = update.effective_message  # type: Optional[Message]
     user = update.effective_user  # type: Optional[User]
@@ -119,7 +119,7 @@ def demote(bot: Bot, update: Update, args: List[str]) -> str:
 @can_pin
 @user_admin
 @loggable
-def pin(bot: Bot, update: Update, args: List[str]) -> str:
+def pin(bot: Bot, update: Update, args: List[str] = None) -> str:
     user = update.effective_user  # type: Optional[User]
     chat = update.effective_chat  # type: Optional[Chat]
 

--- a/IHbot/modules/antiflood.py
+++ b/IHbot/modules/antiflood.py
@@ -56,7 +56,7 @@ def check_flood(bot: Bot, update: Update) -> str:
 @user_admin
 @can_restrict
 @loggable
-def set_flood(bot: Bot, update: Update, args: List[str]) -> str:
+def set_flood(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]

--- a/IHbot/modules/bans.py
+++ b/IHbot/modules/bans.py
@@ -20,7 +20,7 @@ from IHbot.modules.helper_funcs.filters import CustomFilters
 @can_restrict
 @user_admin
 @loggable
-def ban(bot: Bot, update: Update, args: List[str]) -> str:
+def ban(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -83,7 +83,7 @@ def ban(bot: Bot, update: Update, args: List[str]) -> str:
 @can_restrict
 @user_admin
 @loggable
-def temp_ban(bot: Bot, update: Update, args: List[str]) -> str:
+def temp_ban(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -167,7 +167,7 @@ def temp_ban(bot: Bot, update: Update, args: List[str]) -> str:
 @can_restrict
 @user_admin
 @loggable
-def kick(bot: Bot, update: Update, args: List[str]) -> str:
+def kick(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -270,7 +270,7 @@ def banme(bot: Bot, update: Update):
 @can_restrict
 @user_admin
 @loggable
-def unban(bot: Bot, update: Update, args: List[str]) -> str:
+def unban(bot: Bot, update: Update, args: List[str] = None) -> str:
     message = update.effective_message  # type: Optional[Message]
     user = update.effective_user  # type: Optional[User]
     chat = update.effective_chat  # type: Optional[Chat]
@@ -317,7 +317,7 @@ def unban(bot: Bot, update: Update, args: List[str]) -> str:
 @can_restrict
 @user_admin
 @loggable
-def sban(bot: Bot, update: Update, args: List[str]) -> str:
+def sban(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]

--- a/IHbot/modules/blacklist.py
+++ b/IHbot/modules/blacklist.py
@@ -19,7 +19,7 @@ BASE_BLACKLIST_STRING = "Current <b>blacklisted</b> words:\n"
 
 
 @run_async
-def blacklist(bot: Bot, update: Update, args: List[str]):
+def blacklist(bot: Bot, update: Update, args: List[str] = None):
     msg = update.effective_message  # type: Optional[Message]
     chat = update.effective_chat  # type: Optional[Chat]
 

--- a/IHbot/modules/disable.py
+++ b/IHbot/modules/disable.py
@@ -66,7 +66,7 @@ if is_module_loaded(FILENAME):
 
     @run_async
     @user_admin
-    def disable(bot: Bot, update: Update, args: List[str]):
+    def disable(bot: Bot, update: Update, args: List[str] = None):
         chat = update.effective_chat  # type: Optional[Chat]
         if len(args) >= 1:
             disable_cmd = args[0]
@@ -86,7 +86,7 @@ if is_module_loaded(FILENAME):
 
     @run_async
     @user_admin
-    def enable(bot: Bot, update: Update, args: List[str]):
+    def enable(bot: Bot, update: Update, args: List[str] = None):
         chat = update.effective_chat  # type: Optional[Chat]
         if len(args) >= 1:
             enable_cmd = args[0]

--- a/IHbot/modules/dogbin.py
+++ b/IHbot/modules/dogbin.py
@@ -15,7 +15,7 @@ from IHbot.modules.disable import DisableAbleCommandHandler
 BASE_URL = 'https://del.dog'
 
 @run_async
-def paste(bot: Bot, update: Update, args: List[str]):
+def paste(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if message.reply_to_message:
@@ -46,7 +46,7 @@ def paste(bot: Bot, update: Update, args: List[str]):
     update.effective_message.reply_text(reply, parse_mode=ParseMode.MARKDOWN)
 
 @run_async
-def get_paste_content(bot: Bot, update: Update, args: List[str]):
+def get_paste_content(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if len(args) >= 1:
@@ -79,7 +79,7 @@ def get_paste_content(bot: Bot, update: Update, args: List[str]):
     update.effective_message.reply_text('```' + escape_markdown(r.text) + '```', parse_mode=ParseMode.MARKDOWN)
 
 @run_async
-def get_paste_stats(bot: Bot, update: Update, args: List[str]):
+def get_paste_stats(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if len(args) >= 1:

--- a/IHbot/modules/global_bans.py
+++ b/IHbot/modules/global_bans.py
@@ -44,7 +44,7 @@ UNGBAN_ERRORS = {
 
 
 @run_async
-def gban(bot: Bot, update: Update, args: List[str]):
+def gban(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message  # type: Optional[Message]
 
     user_id, reason = extract_user_and_text(message, args)
@@ -135,7 +135,7 @@ def gban(bot: Bot, update: Update, args: List[str]):
     message.reply_text("Person has been \"Dealt with\".")
 
 @run_async
-def ungban(bot: Bot, update: Update, args: List[str]):
+def ungban(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message  # type: Optional[Message]
 
     user_id = extract_user(message, args)
@@ -251,7 +251,7 @@ def enforce_gban(bot: Bot, update: Update):
 
 @run_async
 @user_admin
-def gbanstat(bot: Bot, update: Update, args: List[str]):
+def gbanstat(bot: Bot, update: Update, args: List[str] = None):
     if len(args) > 0:
         if args[0].lower() in ["on", "yes"]:
             sql.enable_gbans(update.effective_chat.id)

--- a/IHbot/modules/global_kicks.py
+++ b/IHbot/modules/global_kicks.py
@@ -28,7 +28,7 @@ GKICK_ERRORS = {
 }
 
 @run_async
-def gkick(bot: Bot, update: Update, args: List[str]):
+def gkick(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     user_id = extract_user(message, args)
     try:

--- a/IHbot/modules/global_mutes.py
+++ b/IHbot/modules/global_mutes.py
@@ -19,7 +19,7 @@ GMUTE_ENFORCE_GROUP = 6
 
 
 @run_async
-def gmute(bot: Bot, update: Update, args: List[str]):
+def gmute(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message  # type: Optional[Message]
 
     user_id, reason = extract_user_and_text(message, args)
@@ -130,7 +130,7 @@ def gmute(bot: Bot, update: Update, args: List[str]):
     message.reply_text("They won't be talking again anytime soon.")
 
 @run_async
-def ungmute(bot: Bot, update: Update, args: List[str]):
+def ungmute(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message  # type: Optional[Message]
 
     user_id = extract_user(message, args)
@@ -262,7 +262,7 @@ def enforce_gmute(bot: Bot, update: Update):
 
 @run_async
 @user_admin
-def gmutestat(bot: Bot, update: Update, args: List[str]):
+def gmutestat(bot: Bot, update: Update, args: List[str] = None):
     if len(args) > 0:
         if args[0].lower() in ["on", "yes"]:
             sql.enable_gmutes(update.effective_chat.id)

--- a/IHbot/modules/helper_funcs/cas_api.py
+++ b/IHbot/modules/helper_funcs/cas_api.py
@@ -1,0 +1,73 @@
+# # DON'T BE A DICK PUBLIC LICENSE B
+#
+# > Version 1.1, October 2020
+#
+# > Copyright (C) 2020 Nuno Penim
+#
+#  Everyone is permitted to copy and distribute verbatim or modified
+#  copies (as long as the name changes) of this license document.
+#
+# > DON'T BE A DICK PUBLIC LICENSE B
+# > TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+#
+#  1. Do whatever you like with the original work, just don't be a dick.
+#
+#      Being a dick includes - but is not limited to - the following instances:
+#
+# 	 1a. Outright copyright infringement - Don't just copy the original work/works and change the name.
+# 	 1b. Selling the unmodified original with no work done what-so-ever, that's REALLY being a dick.
+# 	 1c. Modifying the original work to contain hidden harmful content. That would make you a PROPER dick.
+# 	 1d. Selling a project with educational purposes without consulting the original creator. That would make you a BAG of dicks.
+#
+#  2. If you become rich through modifications, related works/services, or supporting the original work,
+#  share the love. Only a dick would make loads off this work and not buy the original work's
+#  creator(s) a beer or a pizza.
+#
+#  3. Code is provided with no warranty. Using somebody else's code and bitching when it goes wrong makes
+#  you a DONKEY dick. Fix the problem yourself or submit a [bug report](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html), so that the
+#  original creator can attempt to fix the problem. Just don't bitch about it.
+
+# https://github.com/nunopenim/pyCombotCAS_API
+
+import json
+import datetime
+import requests
+
+VERSION = "1.4.0"
+CAS_QUERY_URL = "https://api.cas.chat/check?user_id="
+DL_DIR = "./csvExports"
+
+
+def get_user_data(user_id):
+    with requests.request('GET', CAS_QUERY_URL + str(user_id)) as userdata_raw:
+        userdata = json.loads(userdata_raw.text)
+        return userdata
+
+
+def isbanned(userdata):
+    return userdata['ok']
+
+
+def banchecker(userdata):
+    return isbanned(userdata)
+
+
+def vercheck() -> str:
+    return str(VERSION)
+
+
+def offenses(userdata):
+    try:
+        offenses = userdata['result']['offenses']
+        return str(offenses)
+    except:
+        return None
+
+
+def timeadded(userdata):
+    try:
+        timeEp = userdata['result']['time_added']
+        timeHuman = datetime.datetime.utcfromtimestamp(timeEp).strftime('%H:%M:%S, %d-%m-%Y')
+        return timeHuman
+    except:
+        return None

--- a/IHbot/modules/helper_funcs/extraction.py
+++ b/IHbot/modules/helper_funcs/extraction.py
@@ -18,11 +18,11 @@ def id_from_reply(message):
     return user_id, res[1]
 
 
-def extract_user(message: Message, args: List[str]) -> Optional[int]:
+def extract_user(message: Message, args: List[str] = None) -> Optional[int]:
     return extract_user_and_text(message, args)[0]
 
 
-def extract_user_and_text(message: Message, args: List[str]) -> (Optional[int], Optional[str]):
+def extract_user_and_text(message: Message, args: List[str] = None) -> (Optional[int], Optional[str]):
     prev_message = message.reply_to_message
     split_text = message.text.split(None, 1)
 

--- a/IHbot/modules/locks.py
+++ b/IHbot/modules/locks.py
@@ -99,7 +99,7 @@ def locktypes(bot: Bot, update: Update):
 @user_admin
 @bot_can_delete
 @loggable
-def lock(bot: Bot, update: Update, args: List[str]) -> str:
+def lock(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -140,7 +140,7 @@ def lock(bot: Bot, update: Update, args: List[str]) -> str:
 @run_async
 @user_admin
 @loggable
-def unlock(bot: Bot, update: Update, args: List[str]) -> str:
+def unlock(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]

--- a/IHbot/modules/lyrics.py
+++ b/IHbot/modules/lyrics.py
@@ -11,7 +11,7 @@ from requests import get
 LYRICSINFO = "\n[Full Lyrics](http://lyrics.wikia.com/wiki/%s:%s)"
 
 @run_async
-def lyrics(bot: Bot, update: Update, args: List[str]):
+def lyrics(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     text = message.text[len('/lyrics '):]
     song = " ".join(args).split("- ")

--- a/IHbot/modules/math.py
+++ b/IHbot/modules/math.py
@@ -12,37 +12,37 @@ def join(args):
     return x
 
 @run_async
-def simplify(bot: Bot, update: Update, args: List[str]):
+def simplify(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     message.reply_text(newton.simplify('{}'.format(join(args))))
 
 @run_async
-def factor(bot: Bot, update: Update, args: List[str]):
+def factor(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     message.reply_text(newton.factor('{}'.format(join(args))))
 
 @run_async
-def derive(bot: Bot, update: Update, args: List[str]):
+def derive(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     message.reply_text(newton.derive('{}'.format(join(args))))
 
 @run_async
-def integrate(bot: Bot, update: Update, args: List[str]):
+def integrate(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     message.reply_text(newton.integrate('{}'.format(join(args))))
 
 @run_async
-def zeroes(bot: Bot, update: Update, args: List[str]):
+def zeroes(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     message.reply_text(newton.zeroes('{}'.format(join(args))))
 
 @run_async
-def tangent(bot: Bot, update: Update, args: List[str]):
+def tangent(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     message.reply_text(newton.tangent('{}'.format(join(args))))
 
 @run_async
-def area(bot: Bot, update: Update, args: List[str]):
+def area(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     message.reply_text(newton.area('{}'.format(join(args))))
 

--- a/IHbot/modules/memes.py
+++ b/IHbot/modules/memes.py
@@ -82,7 +82,7 @@ def stretch(bot: Bot, update: Update):
     message.reply_to_message.reply_text(reply_text)
 
 @run_async
-def vapor(bot: Bot, update: Update, args: List[str]):
+def vapor(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if not message.reply_to_message:

--- a/IHbot/modules/misc.py
+++ b/IHbot/modules/misc.py
@@ -165,7 +165,7 @@ def runs(bot: Bot, update: Update):
     update.effective_message.reply_text(random.choice(RUN_STRINGS))
 
 @run_async
-def slap(bot: Bot, update: Update, args: List[str]):
+def slap(bot: Bot, update: Update, args: List[str] = None):
     bot.sendChatAction(update.effective_chat.id, "typing") # Bot typing before send messages
     msg = update.effective_message  # type: Optional[Message]
 
@@ -211,7 +211,7 @@ def get_bot_ip(bot: Bot, update: Update):
     update.message.reply_text(res.text)
 
 @run_async
-def get_id(bot: Bot, update: Update, args: List[str]):
+def get_id(bot: Bot, update: Update, args: List[str] = None):
     bot.sendChatAction(update.effective_chat.id, "typing") # Bot typing before send messages
     user_id = extract_user(update.effective_message, args)
     if user_id:
@@ -240,7 +240,7 @@ def get_id(bot: Bot, update: Update, args: List[str]):
                                                 parse_mode=ParseMode.MARKDOWN)
 
 @run_async
-def info(bot: Bot, update: Update, args: List[str]):
+def info(bot: Bot, update: Update, args: List[str] = None):
     bot.sendChatAction(update.effective_chat.id, "typing") # Bot typing before send messages
     msg = update.effective_message  # type: Optional[Message]
     user_id = extract_user(update.effective_message, args)
@@ -295,7 +295,7 @@ def info(bot: Bot, update: Update, args: List[str]):
     update.effective_message.reply_text(text, parse_mode=ParseMode.HTML)
 
 @run_async
-def get_time(bot: Bot, update: Update, args: List[str]):
+def get_time(bot: Bot, update: Update, args: List[str] = None):
     if len(args) == 0:
         update.effective_message.reply_text("Write a location to check the time.")
         return
@@ -374,7 +374,7 @@ def getlink(bot: Bot, update: Update, args: List[int]):
 @bot_admin
 @can_restrict
 @user_admin
-def safe_mode(bot: Bot, update: Update, args: List[str]):
+def safe_mode(bot: Bot, update: Update, args: List[str] = None):
     chat = update.effective_chat
     message = update.effective_message
     if not args:
@@ -440,7 +440,7 @@ def markdown_help(bot: Bot, update: Update):
 def stats(bot: Bot, update: Update):
     update.effective_message.reply_text("Current stats:\n" + "\n".join([mod.__stats__() for mod in STATS]))
 
-def gps(bot: Bot, update: Update, args: List[str]):
+def gps(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
     if len(args) == 0:
         update.effective_message.reply_text("That was a funny joke, but no really, put in a location")

--- a/IHbot/modules/msg_deleting.py
+++ b/IHbot/modules/msg_deleting.py
@@ -15,7 +15,7 @@ from IHbot.modules.log_channel import loggable
 @run_async
 @user_admin
 @loggable
-def purge(bot: Bot, update: Update, args: List[str]) -> str:
+def purge(bot: Bot, update: Update, args: List[str] = None) -> str:
     msg = update.effective_message  # type: Optional[Message]
     if msg.reply_to_message:
         user = update.effective_user  # type: Optional[User]

--- a/IHbot/modules/muting.py
+++ b/IHbot/modules/muting.py
@@ -19,7 +19,7 @@ from IHbot.modules.log_channel import loggable
 @bot_admin
 @user_admin
 @loggable
-def mute(bot: Bot, update: Update, args: List[str]) -> str:
+def mute(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -64,7 +64,7 @@ def mute(bot: Bot, update: Update, args: List[str]) -> str:
 @bot_admin
 @user_admin
 @loggable
-def unmute(bot: Bot, update: Update, args: List[str]) -> str:
+def unmute(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -108,7 +108,7 @@ def unmute(bot: Bot, update: Update, args: List[str]) -> str:
 @can_restrict
 @user_admin
 @loggable
-def temp_mute(bot: Bot, update: Update, args: List[str]) -> str:
+def temp_mute(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -188,7 +188,7 @@ def temp_mute(bot: Bot, update: Update, args: List[str]) -> str:
 @bot_admin
 @user_admin
 @loggable
-def nomedia(bot: Bot, update: Update, args: List[str]) -> str:
+def nomedia(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -235,7 +235,7 @@ def nomedia(bot: Bot, update: Update, args: List[str]) -> str:
 @bot_admin
 @user_admin
 @loggable
-def media(bot: Bot, update: Update, args: List[str]) -> str:
+def media(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]
@@ -278,7 +278,7 @@ def media(bot: Bot, update: Update, args: List[str]) -> str:
 @can_restrict
 @user_admin
 @loggable
-def temp_nomedia(bot: Bot, update: Update, args: List[str]) -> str:
+def temp_nomedia(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     message = update.effective_message  # type: Optional[Message]

--- a/IHbot/modules/notes.py
+++ b/IHbot/modules/notes.py
@@ -110,7 +110,7 @@ def get(bot, update, notename, show_none=True, no_format=False):
 
 
 @run_async
-def cmd_get(bot: Bot, update: Update, args: List[str]):
+def cmd_get(bot: Bot, update: Update, args: List[str] = None):
     if len(args) >= 2 and args[1].lower() == "noformat":
         get(bot, update, args[0], show_none=True, no_format=True)
     elif len(args) >= 1:
@@ -163,7 +163,7 @@ def save(bot: Bot, update: Update):
 
 @run_async
 @user_admin
-def clear(bot: Bot, update: Update, args: List[str]):
+def clear(bot: Bot, update: Update, args: List[str] = None):
     chat_id = update.effective_chat.id
     if len(args) >= 1:
         notename = args[0]

--- a/IHbot/modules/remote_cmds.py
+++ b/IHbot/modules/remote_cmds.py
@@ -84,7 +84,7 @@ RUNMUTE_ERRORS = {
 
 @run_async
 @bot_admin
-def rban(bot: Bot, update: Update, args: List[str]):
+def rban(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if not args:
@@ -151,7 +151,7 @@ def rban(bot: Bot, update: Update, args: List[str]):
 
 @run_async
 @bot_admin
-def runban(bot: Bot, update: Update, args: List[str]):
+def runban(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if not args:
@@ -218,7 +218,7 @@ def runban(bot: Bot, update: Update, args: List[str]):
 
 @run_async
 @bot_admin
-def rkick(bot: Bot, update: Update, args: List[str]):
+def rkick(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if not args:
@@ -285,7 +285,7 @@ def rkick(bot: Bot, update: Update, args: List[str]):
 
 @run_async
 @bot_admin
-def rmute(bot: Bot, update: Update, args: List[str]):
+def rmute(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if not args:
@@ -352,7 +352,7 @@ def rmute(bot: Bot, update: Update, args: List[str]):
 
 @run_async
 @bot_admin
-def runmute(bot: Bot, update: Update, args: List[str]):
+def runmute(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message
 
     if not args:

--- a/IHbot/modules/reporting.py
+++ b/IHbot/modules/reporting.py
@@ -16,7 +16,7 @@ REPORT_GROUP = 5
 
 @run_async
 @user_admin
-def report_setting(bot: Bot, update: Update, args: List[str]):
+def report_setting(bot: Bot, update: Update, args: List[str] = None):
     chat = update.effective_chat  # type: Optional[Chat]
     msg = update.effective_message  # type: Optional[Message]
 

--- a/IHbot/modules/special.py
+++ b/IHbot/modules/special.py
@@ -48,7 +48,7 @@ def banall(bot: Bot, update: Update, args: List[int]):
 
 
 @run_async
-def snipe(bot: Bot, update: Update, args: List[str]):
+def snipe(bot: Bot, update: Update, args: List[str] = None):
     try:
         chat_id = str(args[0])
         del args[0]
@@ -114,7 +114,7 @@ def slist(bot: Bot, update: Update):
 
 @run_async
 @user_admin
-def birthday(bot: Bot, update: Update, args: List[str]):
+def birthday(bot: Bot, update: Update, args: List[str] = None):
     if args:
         username = str(",".join(args))
     bot.sendChatAction(update.effective_chat.id, "typing") # Bot typing before send messages

--- a/IHbot/modules/userinfo.py
+++ b/IHbot/modules/userinfo.py
@@ -13,7 +13,7 @@ from IHbot.modules.helper_funcs.extraction import extract_user
 
 
 @run_async
-def about_me(bot: Bot, update: Update, args: List[str]):
+def about_me(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message  # type: Optional[Message]
     user_id = extract_user(message, args)
 
@@ -50,7 +50,7 @@ def set_about_me(bot: Bot, update: Update):
 
 
 @run_async
-def about_bio(bot: Bot, update: Update, args: List[str]):
+def about_bio(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message  # type: Optional[Message]
 
     user_id = extract_user(message, args)

--- a/IHbot/modules/users.py
+++ b/IHbot/modules/users.py
@@ -70,7 +70,7 @@ def broadcast(bot: Bot, update: Update):
 
 
 @run_async
-def restrict_group(bot: Bot, update: Update, args: List[str]) -> str:
+def restrict_group(bot: Bot, update: Update, args: List[str] = None) -> str:
     message = update.effective_message  # type: Optional[Message]
 
     # Check if there is only one argument
@@ -141,7 +141,7 @@ def new_message(bot: Bot, update: Update):  # Leave group when a message is sent
 
 
 @run_async
-def unrestrict_group(bot: Bot, update: Update, args: List[str]) -> str:
+def unrestrict_group(bot: Bot, update: Update, args: List[str] = None) -> str:
     message = update.effective_message  # type: Optional[Message]
     
     # Check if there is only one argument

--- a/IHbot/modules/warns.py
+++ b/IHbot/modules/warns.py
@@ -130,7 +130,7 @@ def button(bot: Bot, update: Update) -> str:
 @user_admin
 @can_restrict
 @loggable
-def warn_user(bot: Bot, update: Update, args: List[str]) -> str:
+def warn_user(bot: Bot, update: Update, args: List[str] = None) -> str:
     message = update.effective_message  # type: Optional[Message]
     chat = update.effective_chat  # type: Optional[Chat]
     warner = update.effective_user  # type: Optional[User]
@@ -151,7 +151,7 @@ def warn_user(bot: Bot, update: Update, args: List[str]) -> str:
 @user_admin
 @bot_admin
 @loggable
-def reset_warns(bot: Bot, update: Update, args: List[str]) -> str:
+def reset_warns(bot: Bot, update: Update, args: List[str] = None) -> str:
     message = update.effective_message  # type: Optional[Message]
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
@@ -175,7 +175,7 @@ def reset_warns(bot: Bot, update: Update, args: List[str]) -> str:
 
 
 @run_async
-def warns(bot: Bot, update: Update, args: List[str]):
+def warns(bot: Bot, update: Update, args: List[str] = None):
     message = update.effective_message  # type: Optional[Message]
     chat = update.effective_chat  # type: Optional[Chat]
     user_id = extract_user(message, args) or update.effective_user.id
@@ -309,7 +309,7 @@ def reply_filter(bot: Bot, update: Update) -> str:
 @run_async
 @user_admin
 @loggable
-def set_warn_limit(bot: Bot, update: Update, args: List[str]) -> str:
+def set_warn_limit(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     msg = update.effective_message  # type: Optional[Message]
@@ -337,7 +337,7 @@ def set_warn_limit(bot: Bot, update: Update, args: List[str]) -> str:
 
 @run_async
 @user_admin
-def set_warn_strength(bot: Bot, update: Update, args: List[str]):
+def set_warn_strength(bot: Bot, update: Update, args: List[str] = None):
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
     msg = update.effective_message  # type: Optional[Message]

--- a/IHbot/modules/welcome.py
+++ b/IHbot/modules/welcome.py
@@ -8,6 +8,7 @@ from telegram.ext import MessageHandler, Filters, CommandHandler, run_async
 from telegram.utils.helpers import mention_markdown, mention_html, escape_markdown
 
 import IHbot.modules.sql.welcome_sql as sql
+from IHbot.modules.helper_funcs import cas_api as cas
 from IHbot.modules.sql.safemode_sql import is_safemoded
 from IHbot import dispatcher, OWNER_ID, LOGGER
 from IHbot.modules.helper_funcs.chat_status import user_admin, is_user_ban_protected, can_delete
@@ -34,7 +35,8 @@ ENUM_FUNC_MAP = {
 # do not async
 def send(update, message, keyboard, backup_message):
     try:
-        msg = update.effective_message.reply_text(message, parse_mode=ParseMode.MARKDOWN, reply_markup=keyboard, disable_web_page_preview=True)
+        msg = update.effective_message.reply_text(message, parse_mode=ParseMode.MARKDOWN, reply_markup=keyboard,
+                                                  disable_web_page_preview=True)
     except IndexError:
         msg = update.effective_message.reply_text(markdown_parser(backup_message +
                                                                   "\nNote: the current message was "
@@ -88,11 +90,27 @@ def new_member(bot: Bot, update: Update):
         val = is_safemoded(chat.id)
         if val and val.safemode_status:
             try:
-
-                bot.restrict_chat_member(chat.id, mems.id, can_send_messages=True, can_send_media_messages=False, can_send_other_messages=False, can_add_web_page_previews=False, until_date=(int(time.time() + 24 * 60 * 60)))
+                bot.restrict_chat_member(chat.id, mems.id, can_send_messages=True, can_send_media_messages=False,
+                                         can_send_other_messages=False, can_add_web_page_previews=False,
+                                         until_date=(int(time.time() + 24 * 60 * 60)))
             except BadRequest as excp:
                 LOGGER.warning(update)
-                LOGGER.exception("ERROR muting user %s in chat %s (%s) due to %s", mems.id, chat.title, chat.id, excp.message)
+                LOGGER.exception("ERROR muting user %s in chat %s (%s) due to %s", mems.id, chat.title, chat.id,
+                                 excp.message)
+        cas_result = cas.get_user_data(mems.id)
+        if cas.isbanned(cas_result):
+            try:
+                bot.restrict_chat_member(chat.id, mems.id, can_send_messages=False, can_send_media_messages=False,
+                                         can_send_other_messages=False, can_add_web_page_previews=False,
+                                         until_date=(int(time.time() + 24 * 60 * 60 * 365 * 100)))
+                LOGGER.warning(update)
+                LOGGER.info("INFO: TOTALLY muting user %s for 100 years in chat %s (%s) due to CAS saying: %s", mems.id, chat.title,
+                            chat.id,
+                            cas.offenses(cas_result))
+            except BadRequest as excp:
+                LOGGER.warning(update)
+                LOGGER.exception("ERROR muting user %s in chat %s (%s) due to %s", mems.id, chat.title, chat.id,
+                                 excp.message)
 
     should_welc, cust_welcome, welc_type = sql.get_welc_pref(chat.id)
     if should_welc:
@@ -102,7 +120,7 @@ def new_member(bot: Bot, update: Update):
             if new_mem.id == OWNER_ID:
                 update.effective_message.reply_text("Master is in the houseeee, let's get this party started!")
                 bot_member = chat.get_member(bot.id)
-                bot.promoteChatMember(chat_id, new_mem.id,
+                bot.promoteChatMember(chat.id, new_mem.id,
                                       can_change_info=bot_member.can_change_info,
                                       can_post_messages=bot_member.can_post_messages,
                                       can_edit_messages=bot_member.can_edit_messages,
@@ -152,7 +170,6 @@ def new_member(bot: Bot, update: Update):
                 sent = send(update, res, keyboard,
                             sql.DEFAULT_WELCOME.format(first=first_name))  # type: Optional[Message]
             delete_join(bot, update)
-
 
         prev_welc = sql.get_clean_pref(chat.id)
         if prev_welc:
@@ -246,7 +263,8 @@ def welcome(bot: Bot, update: Update, args: List[str]):
                 ENUM_FUNC_MAP[welcome_type](chat.id, welcome_m)
 
             else:
-                ENUM_FUNC_MAP[welcome_type](chat.id, welcome_m, parse_mode=ParseMode.MARKDOWN, disable_web_page_preview=True)
+                ENUM_FUNC_MAP[welcome_type](chat.id, welcome_m, parse_mode=ParseMode.MARKDOWN,
+                                            disable_web_page_preview=True)
 
     elif len(args) >= 1:
         if args[0].lower() in ("on", "yes"):
@@ -292,7 +310,8 @@ def goodbye(bot: Bot, update: Update, args: List[str]):
                 ENUM_FUNC_MAP[goodbye_type](chat.id, goodbye_m)
 
             else:
-                ENUM_FUNC_MAP[goodbye_type](chat.id, goodbye_m, parse_mode=ParseMode.MARKDOWN, disable_web_page_preview=True)
+                ENUM_FUNC_MAP[goodbye_type](chat.id, goodbye_m, parse_mode=ParseMode.MARKDOWN,
+                                            disable_web_page_preview=True)
 
     elif len(args) >= 1:
         if args[0].lower() in ("on", "yes"):
@@ -443,7 +462,7 @@ def del_joined(bot: Bot, update: Update, args: List[str]) -> str:
                "\n#CLEAN_SERVICE" \
                "\n<b>• Admin:</b> {}" \
                "\nHas toggled joined deletion to <code>ON</code>.".format(html.escape(chat.title),
-                                                                         mention_html(user.id, user.first_name))
+                                                                          mention_html(user.id, user.first_name))
     elif args[0].lower() in ("off", "no"):
         sql.set_del_joined(str(chat.id), False)
         update.effective_message.reply_text("I won't delete old joined messages.")
@@ -451,7 +470,7 @@ def del_joined(bot: Bot, update: Update, args: List[str]) -> str:
                "\n#CLEAN_SERVICE" \
                "\n<b>• Admin:</b> {}" \
                "\nHas toggled joined deletion to <code>OFF</code>.".format(html.escape(chat.title),
-                                                                          mention_html(user.id, user.first_name))
+                                                                           mention_html(user.id, user.first_name))
     else:
         # idek what you're writing, say yes or no
         update.effective_message.reply_text("I understand 'on/yes' or 'off/no' only!")
@@ -466,7 +485,7 @@ def delete_join(bot: Bot, update: Update):
         del_join = sql.get_del_pref(chat.id)
         if del_join:
             update.message.delete()
-            
+
 
 WELC_HELP_TXT = "Your group's welcome/goodbye messages can be personalised in multiple ways. If you want the messages" \
                 " to be individually generated, like the default welcome message is, you can use *these* variables:\n" \

--- a/IHbot/modules/welcome.py
+++ b/IHbot/modules/welcome.py
@@ -235,7 +235,7 @@ def left_member(bot: Bot, update: Update):
 
 @run_async
 @user_admin
-def welcome(bot: Bot, update: Update, args: List[str]):
+def welcome(bot: Bot, update: Update, args: List[str] = None):
     chat = update.effective_chat  # type: Optional[Chat]
     # if no args, show current replies.
     if len(args) == 0 or args[0].lower() == "noformat":
@@ -282,7 +282,7 @@ def welcome(bot: Bot, update: Update, args: List[str]):
 
 @run_async
 @user_admin
-def goodbye(bot: Bot, update: Update, args: List[str]):
+def goodbye(bot: Bot, update: Update, args: List[str] = None):
     chat = update.effective_chat  # type: Optional[Chat]
 
     if len(args) == 0 or args[0] == "noformat":
@@ -406,7 +406,7 @@ def reset_goodbye(bot: Bot, update: Update) -> str:
 @run_async
 @user_admin
 @loggable
-def clean_welcome(bot: Bot, update: Update, args: List[str]) -> str:
+def clean_welcome(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
 
@@ -443,7 +443,7 @@ def clean_welcome(bot: Bot, update: Update, args: List[str]) -> str:
 @run_async
 @user_admin
 @loggable
-def del_joined(bot: Bot, update: Update, args: List[str]) -> str:
+def del_joined(bot: Bot, update: Update, args: List[str] = None) -> str:
     chat = update.effective_chat  # type: Optional[Chat]
     user = update.effective_user  # type: Optional[User]
 


### PR DESCRIPTION
`/start`, `/promote` et al were failing without error when a default argument was not provided.
This also adds a silent mute-on-join for CAS-banned individuals.

TODO: add a message explaining that they are CAS-banned ;-)